### PR TITLE
Insert length gates in create() and edit()

### DIFF
--- a/cogs/characters.py
+++ b/cogs/characters.py
@@ -241,7 +241,10 @@ class Characters(commands.Cog):
             await ctx.send(await _(ctx, "You do not own this character!"))
             return
         
-        if len(attribute) + len(value) > 1024:
+        if attribute == "description" && if len(content) + len(response.content) > 3500:
+            await ctx.send(await _(ctx, "Can't have a description longer than 3500 characters!"))
+            return
+        elif len(attribute) + len(value) > 1024:
             await ctx.send(await _(ctx, "Can't have an attribute longer than 1024 characters!"))
             return
         

--- a/cogs/characters.py
+++ b/cogs/characters.py
@@ -173,6 +173,9 @@ class Characters(commands.Cog):
                         key, value = val.split(": ")
                         key = key.strip()
                         value = value.strip()
+                        if len(key) + len(value) > 1024:
+                            await ctx.send(await _(ctx, "Can't have an attribute longer than 1024 characters!"))
+                            return
                         character["meta"][key] = value
                     else:
                         break
@@ -237,7 +240,11 @@ class Characters(commands.Cog):
         if character.owner != ctx.author.id and not is_mod:
             await ctx.send(await _(ctx, "You do not own this character!"))
             return
-
+        
+        if len(attribute) + len(value) > 1024:
+            await ctx.send(await _(ctx, "Can't have an attribute longer than 1024 characters!"))
+            return
+        
         character = list(character)
         if attribute == "name":
             await self.bot.di.remove_character(ctx.guild, character[0])

--- a/cogs/characters.py
+++ b/cogs/characters.py
@@ -241,7 +241,7 @@ class Characters(commands.Cog):
             await ctx.send(await _(ctx, "You do not own this character!"))
             return
         
-        if attribute == "description" && if len(content) + len(response.content) > 3500:
+        if attribute == "description" and len(content) + len(response.content) > 3500:
             await ctx.send(await _(ctx, "Can't have a description longer than 3500 characters!"))
             return
         elif len(attribute) + len(value) > 1024:


### PR DESCRIPTION
Inserted checks to make sure the combined length of an attribute title and it's value did not exceed 1024. If so, print warning and return.