### PR TITLE
Adding default message for no prefix set

### DIFF
--- a/cogs/settings.py
+++ b/cogs/settings.py
@@ -415,7 +415,7 @@ class Settings(commands.Cog):
         Requires Bot Moderator or Bot Admin"""
         prefix = self.bot.prefixes.get(str(ctx.guild.id))
         if len(prefix) == 0:
-            await ctx.send("You have not set a prefix yet")
+            await ctx.send("You have not set a custom prefix yet")
         else:
             await ctx.send(prefix)
 

--- a/cogs/settings.py
+++ b/cogs/settings.py
@@ -414,7 +414,10 @@ class Settings(commands.Cog):
 
         Requires Bot Moderator or Bot Admin"""
         prefix = self.bot.prefixes.get(str(ctx.guild.id))
-        await ctx.send(prefix)
+        if len(prefix) == 0:
+            await ctx.send("You have not set a prefix yet")
+        else:
+            await ctx.send(prefix)
 
     @commands.command(disabled=True)
     @checks.admin_or_permissions()


### PR DESCRIPTION
So we dont have people roaming into the bug report channel complaining about a non bug all the time